### PR TITLE
Fix token handling in workflow

### DIFF
--- a/.github/workflows/build-tags.yml
+++ b/.github/workflows/build-tags.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Build tag table
       env:
-        GH_TOKEN: ${{ secrets.GH_PAT }}   # create a PAT with "public_repo"
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_USER:  ${{ github.repository_owner }}
       run: |
         python scripts/make_tags.py

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # starclass
-Create Taxonomy and Tags for Liked Github Repositories
+Fetch your starred repositories and generate a markdown table of tags.
+
+The workflow uses the built in `GITHUB_TOKEN`.  For personal use you can run
+the script locally:
+
+```bash
+GH_USER=<your-user> python scripts/make_tags.py
+```
+
+Providing `GH_TOKEN` is optional but increases the API rate limit.

--- a/scripts/make_tags.py
+++ b/scripts/make_tags.py
@@ -5,12 +5,16 @@ repo_full_name | tag1, tag2, ...
 """
 import os, sys, pathlib, json, time
 from slugify import slugify
-from github import Github
+from github import Github, GithubException
 
-TOKEN = os.getenv("GH_TOKEN")         # set in workflow secrets
+TOKEN = os.getenv("GH_TOKEN")         # optional GitHub token
+USER  = os.getenv("GH_USER")          # username for unauth'd requests
 
-gh   = Github(TOKEN, per_page=100)
-user = gh.get_user()
+if not (TOKEN or USER):
+    sys.exit("Set GH_USER or GH_TOKEN to identify account")
+
+gh = Github(TOKEN or None, per_page=100)
+user = gh.get_user(USER) if USER else gh.get_user()
 
 rows = []
 for repo in user.get_starred():


### PR DESCRIPTION
## Summary
- allow running `make_tags.py` without a PAT
- use `GITHUB_TOKEN` in the build workflow
- document how to run the script manually

## Testing
- `python -m py_compile scripts/make_tags.py`

------
https://chatgpt.com/codex/tasks/task_e_686ebec995f8832fa03f58a175a0349a