### PR TITLE
Fix GithubException import

### DIFF
--- a/scripts/make_tags.py
+++ b/scripts/make_tags.py
@@ -6,6 +6,7 @@ repo_full_name | tag1, tag2, ...
 import os, sys, pathlib, json, time
 from slugify import slugify
 from github import Github
+from github.GithubException import GithubException
 
 TOKEN = os.getenv("GH_TOKEN")         # set in workflow secrets
 


### PR DESCRIPTION
## Summary
- fix missing import for GithubException in star tag script

## Testing
- `python3 -m py_compile scripts/make_tags.py`


------
https://chatgpt.com/codex/tasks/task_e_686ebe977cb4832fadf89fdfd3a9f19e